### PR TITLE
Put fixed endpoint to support multiple additional images, as well as controls to support this

### DIFF
--- a/app/portal/_components/(artwork-controls)/edit-artwork-form.tsx
+++ b/app/portal/_components/(artwork-controls)/edit-artwork-form.tsx
@@ -41,7 +41,7 @@ export function EditArtworkForm({ artwork, onCancel }: EditArtworkFormProps) {
 
       // Append new images if any
       newImages.forEach((file) => {
-        formDataToSend.append("newImages", file);
+        formDataToSend.append("file", file);
       });
 
       const response = await fetch(`/api/artworks/${artwork.id}`, {


### PR DESCRIPTION
Updates artwork API to support PUT command for additional images being added to an existing post, and updated to edit artwork form to support this pattern.

### Changes

- As above

### Contributor checklist

- [x] I've left instructions in this PR for reviewers (where necessary).
- [ ] My changes have (passing) tests.
- [x] I'm confident these changes close or contribute to an existing issue or feature request.
